### PR TITLE
Some minor enhancement

### DIFF
--- a/include/zxorm/error.hpp
+++ b/include/zxorm/error.hpp
@@ -15,7 +15,7 @@ namespace zxorm {
         return (result & 0xff) == SQLITE_CONSTRAINT;
     }
 
-    class Error : std::exception {
+    class Error : public std::exception {
     protected:
         std::string _message;
         int _sqlite_result = SQLITE_OK;

--- a/include/zxorm/orm/record_iterator.hpp
+++ b/include/zxorm/orm/record_iterator.hpp
@@ -50,6 +50,11 @@ namespace zxorm {
             return_t& operator*() {
                 return _current;
             }
+
+            return_t* operator->() {
+                return &_current;
+            }
+
             bool operator==(const iterator& other) const {
                 // nullptr means end
                 if (!_stmt && other._stmt && other._stmt->done()) return true;


### PR DESCRIPTION
Very nice job, it helped me a lot in my work!

I have two minor changes in zxorm, including:

1. I think `zxorm::Error` should be publicly inherited from `std::exception`. This makes it possible to convert `zxorm::Error&` into `std::exception&`, facilitating error handling (e.g., using `boost::current_exception_diagnostic_information()`). The destructor of `std::exception` is a virtual function, thus this public inherits would not cause a memory leak.
2. `operator->` was added to the iterator for conveniently accessing data members without any drawback.