### PR TITLE
Expose Raw Exec Function

### DIFF
--- a/include/zxorm/orm/connection.hpp
+++ b/include/zxorm/orm/connection.hpp
@@ -86,7 +86,6 @@ namespace zxorm {
         auto make_delete_query();
 
         auto make_statement(const std::string& query);
-        void exec(const std::string& query);
 
         // The conditional makes it impossible to deduce the type T apparently :(
         // so the public inserts call this implementation
@@ -176,6 +175,7 @@ namespace zxorm {
         void truncate();
 
         void set_foreign_keys(bool on);
+        void exec(const std::string& query);
     };
 
     template <class... Table>


### PR DESCRIPTION
I'd like the ability to use raw SQL queries for features that aren't yet supported by ZXORM (e.g. adding indices), as such this PR moves the `exec` function signature from `private` to `public`.